### PR TITLE
Updating Manifests to make contrib installable via "qx contrib install"

### DIFF
--- a/qookery/Manifest.json
+++ b/qookery/Manifest.json
@@ -13,7 +13,7 @@
 		],
 		"version": "0.4.1",
 		"qooxdoo-versions": [ "5.0.2", "5.1", "6.0" ],
-		"qooxdoo-range" : "6.0.0-* || 6.x",
+		"qooxdoo-range" : "6.0.0-* | 6.x",
 		"download": "https://github.com/ergobyte/qookery/releases/download/%{version}/qookery.tar.gz",
 		"checksum": "%{sha1-checksum}",
 		"sourceViewUri": "https://github.com/ergobyte/qookery/tree/%{version}/qookery"

--- a/qookery/Manifest.json
+++ b/qookery/Manifest.json
@@ -13,7 +13,7 @@
 		],
 		"version": "0.4.1",
 		"qooxdoo-versions": [ "5.0.2", "5.1", "6.0" ],
-		"qooxdoo-range" : "6.0.0-* | 6.x",
+		"qooxdoo-range" : "^6.0.0-alpha",
 		"download": "https://github.com/ergobyte/qookery/releases/download/%{version}/qookery.tar.gz",
 		"checksum": "%{sha1-checksum}",
 		"sourceViewUri": "https://github.com/ergobyte/qookery/tree/%{version}/qookery"

--- a/qookery/Manifest.json
+++ b/qookery/Manifest.json
@@ -11,8 +11,9 @@
 			{ "name": "Stelios Joseph Karras (jkarr)", "email": "jkarr@ergobyte.gr" },
 			{ "name": "Nikos Lamprakis (nikoslam)", "email": "nikoslam@ergobyte.gr" }
 		],
-		"version": "master",
-		"qooxdoo-versions": [ "5.0.2", "5.1" ],
+		"version": "0.4.1",
+		"qooxdoo-versions": [ "5.0.2", "5.1", "6.0" ],
+		"qooxdoo-range" : "6.0.0-* || 6.x",
 		"download": "https://github.com/ergobyte/qookery/releases/download/%{version}/qookery.tar.gz",
 		"checksum": "%{sha1-checksum}",
 		"sourceViewUri": "https://github.com/ergobyte/qookery/tree/%{version}/qookery"

--- a/qookeryace/Manifest.json
+++ b/qookeryace/Manifest.json
@@ -9,7 +9,7 @@
 		],
 		"version": "0.4.1",
 		"qooxdoo-versions": [ "5.0.2", "5.1", "6.0" ],
-		"qooxdoo-range" : "6.0.0-* | 6.x",
+		"qooxdoo-range" : "^6.0.0-alpha",
 		"download": "https://github.com/ergobyte/qookery/releases/download/%{version}/qookery.tar.gz",
 		"checksum": "%{sha1-checksum}",
 		"sourceViewUri": "https://github.com/ergobyte/qookery/tree/%{version}/qookery"

--- a/qookeryace/Manifest.json
+++ b/qookeryace/Manifest.json
@@ -7,8 +7,9 @@
 		"authors": [
 			{ "name": "George Nikolaidis (geonik)", "email": "geonik@ergobyte.gr" }
 		],
-		"version": "master",
-		"qooxdoo-versions": [ "5.0.2", "5.1" ],
+		"version": "0.4.1",
+		"qooxdoo-versions": [ "5.0.2", "5.1", "6.0" ],
+		"qooxdoo-range" : "6.0.0-* || 6.x",
 		"download": "https://github.com/ergobyte/qookery/releases/download/%{version}/qookery.tar.gz",
 		"checksum": "%{sha1-checksum}",
 		"sourceViewUri": "https://github.com/ergobyte/qookery/tree/%{version}/qookery"

--- a/qookeryace/Manifest.json
+++ b/qookeryace/Manifest.json
@@ -9,7 +9,7 @@
 		],
 		"version": "0.4.1",
 		"qooxdoo-versions": [ "5.0.2", "5.1", "6.0" ],
-		"qooxdoo-range" : "6.0.0-* || 6.x",
+		"qooxdoo-range" : "6.0.0-* | 6.x",
 		"download": "https://github.com/ergobyte/qookery/releases/download/%{version}/qookery.tar.gz",
 		"checksum": "%{sha1-checksum}",
 		"sourceViewUri": "https://github.com/ergobyte/qookery/tree/%{version}/qookery"

--- a/qookerycalendar/Manifest.json
+++ b/qookerycalendar/Manifest.json
@@ -11,7 +11,7 @@
 		],
 		"version": "0.4.1",
 		"qooxdoo-versions": [ "5.0.2", "5.1", "6.0" ],
-		"qooxdoo-range" : "6.0.0-* || 6.x",
+		"qooxdoo-range" : "6.0.0-* | 6.x",
 		"download": "https://github.com/ergobyte/qookery/releases/download/%{version}/qookery.tar.gz",
 		"checksum": "%{sha1-checksum}",
 		"sourceViewUri": "https://github.com/ergobyte/qookery/tree/%{version}/qookery"

--- a/qookerycalendar/Manifest.json
+++ b/qookerycalendar/Manifest.json
@@ -9,8 +9,9 @@
 			{ "name": "George Nikolaidis (geonik)", "email": "geonik@ergobyte.gr" },
 			{ "name": "Stelios Joseph Karras (jkarr)", "email": "jkarr@ergobyte.gr" }
 		],
-		"version": "master",
-		"qooxdoo-versions": [ "5.0.2", "5.1" ],
+		"version": "0.4.1",
+		"qooxdoo-versions": [ "5.0.2", "5.1", "6.0" ],
+		"qooxdoo-range" : "6.0.0-* || 6.x",
 		"download": "https://github.com/ergobyte/qookery/releases/download/%{version}/qookery.tar.gz",
 		"checksum": "%{sha1-checksum}",
 		"sourceViewUri": "https://github.com/ergobyte/qookery/tree/%{version}/qookery"

--- a/qookerycalendar/Manifest.json
+++ b/qookerycalendar/Manifest.json
@@ -11,7 +11,7 @@
 		],
 		"version": "0.4.1",
 		"qooxdoo-versions": [ "5.0.2", "5.1", "6.0" ],
-		"qooxdoo-range" : "6.0.0-* | 6.x",
+		"qooxdoo-range" : "^6.0.0-alpha",
 		"download": "https://github.com/ergobyte/qookery/releases/download/%{version}/qookery.tar.gz",
 		"checksum": "%{sha1-checksum}",
 		"sourceViewUri": "https://github.com/ergobyte/qookery/tree/%{version}/qookery"

--- a/qookerydemo/Manifest.json
+++ b/qookerydemo/Manifest.json
@@ -11,8 +11,9 @@
 			{ "name": "Stelios Joseph Karras (jkarr)", "email": "stylkarr@gmail.com" },
 			{ "name": "Nikos Lamprakis (nikoslam)", "email": "nikoslam@ergobyte.gr" }
 		],
-		"version": "master",
-		"qooxdoo-versions": [ "5.0.2", "5.1" ]
+		"version": "0.4.1",
+		"qooxdoo-versions": [ "5.0.2", "5.1", "6.0" ],
+		"qooxdoo-range" : "6.0.0-* || 6.x",
 	},
 	"provides": {
 		"namespace": "qookerydemo",

--- a/qookerydemo/Manifest.json
+++ b/qookerydemo/Manifest.json
@@ -13,7 +13,7 @@
 		],
 		"version": "0.4.1",
 		"qooxdoo-versions": [ "5.0.2", "5.1", "6.0" ],
-		"qooxdoo-range" : "6.0.0-* || 6.x",
+		"qooxdoo-range" : "6.0.0-* | 6.x",
 	},
 	"provides": {
 		"namespace": "qookerydemo",

--- a/qookerydemo/Manifest.json
+++ b/qookerydemo/Manifest.json
@@ -13,7 +13,7 @@
 		],
 		"version": "0.4.1",
 		"qooxdoo-versions": [ "5.0.2", "5.1", "6.0" ],
-		"qooxdoo-range" : "6.0.0-* | 6.x",
+		"qooxdoo-range" : "^6.0.0-alpha",
 	},
 	"provides": {
 		"namespace": "qookerydemo",

--- a/qookerymaps/Manifest.json
+++ b/qookerymaps/Manifest.json
@@ -8,8 +8,9 @@
 			{ "name": "George Nikolaidis (geonik)", "email": "geonik@ergobyte.gr" },
 			{ "name": "Stelios Joseph Karras (jkarr)", "email": "jkarr@ergobyte.gr" }
 		],
-		"version": "master",
-		"qooxdoo-versions": [ "5.0.2", "5.1" ],
+		"version": "0.4.1",
+		"qooxdoo-versions": [ "5.0.2", "5.1", "6.0" ],
+		"qooxdoo-range" : "6.0.0-* || 6.x",
 		"download": "https://github.com/ergobyte/qookery/releases/download/%{version}/qookery.tar.gz",
 		"checksum": "%{sha1-checksum}",
 		"sourceViewUri": "https://github.com/ergobyte/qookery/tree/%{version}/qookery"

--- a/qookerymaps/Manifest.json
+++ b/qookerymaps/Manifest.json
@@ -10,7 +10,7 @@
 		],
 		"version": "0.4.1",
 		"qooxdoo-versions": [ "5.0.2", "5.1", "6.0" ],
-		"qooxdoo-range" : "6.0.0-* || 6.x",
+		"qooxdoo-range" : "6.0.0-* | 6.x",
 		"download": "https://github.com/ergobyte/qookery/releases/download/%{version}/qookery.tar.gz",
 		"checksum": "%{sha1-checksum}",
 		"sourceViewUri": "https://github.com/ergobyte/qookery/tree/%{version}/qookery"

--- a/qookerymaps/Manifest.json
+++ b/qookerymaps/Manifest.json
@@ -10,7 +10,7 @@
 		],
 		"version": "0.4.1",
 		"qooxdoo-versions": [ "5.0.2", "5.1", "6.0" ],
-		"qooxdoo-range" : "6.0.0-* | 6.x",
+		"qooxdoo-range" : "^6.0.0-alpha",
 		"download": "https://github.com/ergobyte/qookery/releases/download/%{version}/qookery.tar.gz",
 		"checksum": "%{sha1-checksum}",
 		"sourceViewUri": "https://github.com/ergobyte/qookery/tree/%{version}/qookery"

--- a/qookerymobile/Manifest.json
+++ b/qookerymobile/Manifest.json
@@ -11,7 +11,7 @@
 		],
 		"version": "0.4.1",
 		"qooxdoo-versions": [ "5.0.2", "5.1", "6.0" ],
-		"qooxdoo-range" : "6.0.0-* || 6.x",
+		"qooxdoo-range" : "6.0.0-* | 6.x",
 		"download": "https://github.com/ergobyte/qookery/releases/download/%{version}/qookery.tar.gz",
 		"checksum": "%{sha1-checksum}",
 		"sourceViewUri": "https://github.com/ergobyte/qookery/tree/%{version}/qookery"

--- a/qookerymobile/Manifest.json
+++ b/qookerymobile/Manifest.json
@@ -19,6 +19,7 @@
 	"provides": {
 		"namespace": "qookery.mobile",
 		"encoding": "utf-8",
+		"resource": "source/resource",
 		"class": "source/class",
 		"type": "component"
 	}

--- a/qookerymobile/Manifest.json
+++ b/qookerymobile/Manifest.json
@@ -9,8 +9,9 @@
 			{ "name": "George Nikolaidis (geonik)", "email": "geonik@ergobyte.gr" },
 			{ "name": "Stelios Joseph Karras (jkarr)", "email": "jkarr@ergobyte.gr" }
 		],
-		"version": "master",
-		"qooxdoo-versions": [ "5.0.2", "5.1" ],
+		"version": "0.4.1",
+		"qooxdoo-versions": [ "5.0.2", "5.1", "6.0" ],
+		"qooxdoo-range" : "6.0.0-* || 6.x",
 		"download": "https://github.com/ergobyte/qookery/releases/download/%{version}/qookery.tar.gz",
 		"checksum": "%{sha1-checksum}",
 		"sourceViewUri": "https://github.com/ergobyte/qookery/tree/%{version}/qookery"

--- a/qookerymobile/Manifest.json
+++ b/qookerymobile/Manifest.json
@@ -11,7 +11,7 @@
 		],
 		"version": "0.4.1",
 		"qooxdoo-versions": [ "5.0.2", "5.1", "6.0" ],
-		"qooxdoo-range" : "6.0.0-* | 6.x",
+		"qooxdoo-range" : "^6.0.0-alpha",
 		"download": "https://github.com/ergobyte/qookery/releases/download/%{version}/qookery.tar.gz",
 		"checksum": "%{sha1-checksum}",
 		"sourceViewUri": "https://github.com/ergobyte/qookery/tree/%{version}/qookery"

--- a/qookeryrichtext/Manifest.json
+++ b/qookeryrichtext/Manifest.json
@@ -11,7 +11,7 @@
 		],
 		"version": "0.4.1",
 		"qooxdoo-versions": [ "5.0.2", "5.1", "6.0" ],
-		"qooxdoo-range" : "6.0.0-* || 6.x",
+		"qooxdoo-range" : "6.0.0-* | 6.x",
 		"download": "https://github.com/ergobyte/qookery/releases/download/%{version}/qookery.tar.gz",
 		"checksum": "%{sha1-checksum}",
 		"sourceViewUri": "https://github.com/ergobyte/qookery/tree/%{version}/qookery"

--- a/qookeryrichtext/Manifest.json
+++ b/qookeryrichtext/Manifest.json
@@ -11,7 +11,7 @@
 		],
 		"version": "0.4.1",
 		"qooxdoo-versions": [ "5.0.2", "5.1", "6.0" ],
-		"qooxdoo-range" : "6.0.0-* | 6.x",
+		"qooxdoo-range" : "^6.0.0-alpha",
 		"download": "https://github.com/ergobyte/qookery/releases/download/%{version}/qookery.tar.gz",
 		"checksum": "%{sha1-checksum}",
 		"sourceViewUri": "https://github.com/ergobyte/qookery/tree/%{version}/qookery"

--- a/qookeryrichtext/Manifest.json
+++ b/qookeryrichtext/Manifest.json
@@ -9,8 +9,9 @@
 			{ "name": "George Nikolaidis (geonik)", "email": "geonik@ergobyte.gr" },
 			{ "name": "Stelios Joseph Karras (jkarr)", "email": "jkarr@ergobyte.gr" }
 		],
-		"version" : "%{version}",
-		"qooxdoo-versions": [ "5.0.2", "5.1" ],
+		"version": "0.4.1",
+		"qooxdoo-versions": [ "5.0.2", "5.1", "6.0" ],
+		"qooxdoo-range" : "6.0.0-* || 6.x",
 		"download": "https://github.com/ergobyte/qookery/releases/download/%{version}/qookery.tar.gz",
 		"checksum": "%{sha1-checksum}",
 		"sourceViewUri": "https://github.com/ergobyte/qookery/tree/%{version}/qookery"


### PR DESCRIPTION
Hi,

at the moment, qookery cannot be installed via `qx contrib install` because the Manifest.json files do not conform to the expected format. This PR fixes this. I have tested it on a fork of qookery which I will remove once the PR is merged:

```
qx contrib list cboulanger/qookery
NAME               VERSION   COMPATIBILITY   REQUIRES    
Qookery            0.4.1     √               ^6.0.0-alpha
Qookery ACE        0.4.1     √               ^6.0.0-alpha
qookery.calendar   0.4.1     √               ^6.0.0-alpha
Qookery Maps       0.4.1     √               ^6.0.0-alpha
qookery mobile     0.4.1     √               ^6.0.0-alpha
qookery.richtext   0.4.1     √               ^6.0.0-alpha
```

Thanks. 