### PR TITLE
Configure path for ACE source files

### DIFF
--- a/qookeryace/source/class/qookery/ace/Bootstrap.js
+++ b/qookeryace/source/class/qookery/ace/Bootstrap.js
@@ -20,7 +20,7 @@ qx.Bootstrap.define("qookery.ace.Bootstrap", {
 
 	defer: function() {
 		qookery.Qookery.getRegistry().registerLibrary("ace", [
-			"qookery/lib/ace/ace.js"
+			(qx.core.Environment.get("qookery.ace.path") || "qookery/lib/ace") + "/ace.js"
 		]);
 		qookery.Qookery.getRegistry().registerComponentType("{http://www.qookery.org/ns/Form/Ace}editor", qookery.ace.internal.AceComponent);
 	}

--- a/qookeryace/source/class/qookery/ace/__init__.js
+++ b/qookeryace/source/class/qookery/ace/__init__.js
@@ -1,0 +1,47 @@
+/*
+	Qookery - Declarative UI Building for Qooxdoo
+
+	Copyright (c) Ergobyte Informatics S.A., www.ergobyte.gr
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+/**
+ * The Qookery ACE plugin allows to use the ACE editor in qookery forms
+ * You will need to download a version of the editor with the required plugins
+ * yourself and include it manually into your application.
+ *
+ * If you are using the javascript compiler, add the following code to your
+ * compile.json file:
+ *
+ * <pre>
+ * "include": [
+ *   "qookery.*",
+ *   "qookery.ace.*"
+ *   ...
+ * ],
+ * "environment": {
+ *   "qookery.ace.path": "subdir-of-resource-folder",
+ *   ...
+ * }
+ * </pre>
+ *
+ * The environment variable "qookery.ace.path" must contain the path to the
+ * directory containing the necessary (minified) ACE source files. This directory
+ * should be a subdirectory the main library's source/resource/app-namespace
+ * folder, since only then will these files be automatically copied to the final
+ * build. For example, if the library namespace is foo, and ace.js is placed
+ * into source/resource/foo/js/ace, define "qookery.ace.path": "foo/js/ace".
+ * The minimal files to get the editor running are "ace.js" and "theme-eclipse.js".
+ *
+ */


### PR DESCRIPTION
Currently, it is not possible to configure the path from which the ACE source files are downloaded.
The path is hardcoded to "qookery/lib/ace" which doesn't allow automatic inclusion into builds with 
the compiler. This PR adds an environment variable "qookery.ace.path" which can be configured to point
to the path where all the ACE files are stored. It also adds documentation to explain this.