### PR TITLE
Make autocomplete work

### DIFF
--- a/qookeryace/source/class/qookery/ace/internal/AceComponent.js
+++ b/qookeryace/source/class/qookery/ace/internal/AceComponent.js
@@ -149,8 +149,11 @@ qx.Class.define("qookery.ace.internal.AceComponent", {
 			editor.setShowInvisibles(this.getAttribute("show-invisibles", false));
 			editor.setShowPrintMargin(this.getAttribute("show-print-margin", true));
 			editor.setOption("cursorStyle", this.getAttribute("cursor-style", "ace"));
-			if(this.getAttribute("auto-complete", "false") === "basic")
-				editor.setOption("enableBasicAutocompletion", true);
+			if(this.getAttribute("auto-complete", "false") === "basic") {
+        editor.setOption("enableBasicAutocompletion", true);
+        editor.setOption("enableLiveAutocompletion", true);
+      }
+
 			editor.$blockScrolling = Infinity;
 			editor.on("change", this.__onChange.bind(this));
 


### PR DESCRIPTION
This adds "editor.setOption("enableLiveAutocompletion", true);" to make autocompletion really work in the ACE browser.